### PR TITLE
Update YMCSKPhysicsBody+Swizzle.m

### DIFF
--- a/PhysicsDebugger/YMCPhysicsDebugger/YMCSKPhysicsBody+Swizzle.m
+++ b/PhysicsDebugger/YMCPhysicsDebugger/YMCSKPhysicsBody+Swizzle.m
@@ -16,7 +16,7 @@ void YMCSwizzler(Class originalClass,
 @implementation SKPhysicsBody (Swizzle)
 
 
-+ (SKPhysicsBody *)bodyWithCircleOfRadiusSwizzled:(float)radius
++ (SKPhysicsBody *)bodyWithCircleOfRadiusSwizzled:(CGFloat)radius
 {
     
     //Save the physicsBody Radius to draw a shape with this afterwards


### PR DESCRIPTION
This will make it so it runs on 64-bit devices.  The CGFloat is a double on 64-bit and not a float, so the radius was always being passed in as 0.
