### PR TITLE
Node Drawing Recursion

### DIFF
--- a/PhysicsDebugger/YMCPhysicsDebugger/YMCSKNode+PhysicsDebug.m
+++ b/PhysicsDebugger/YMCPhysicsDebugger/YMCSKNode+PhysicsDebug.m
@@ -43,7 +43,7 @@ static NSString* debugLayerName = @"physicsDebugLayer";
     int i = 0;
     //draw all children with physicsBodies
     for (SKNode *node in [self children]) {
- 
+        [node drawPhysicsBodies];
         //sort out if it has no physics body
         if(!node.physicsBody) {
             continue;


### PR DESCRIPTION
This fixes issue #5 by recursively calling `drawPhysicsBodies` on all the children
