### PR TITLE
Fix for crash if nodesNBodies array empty.

### DIFF
--- a/PhysicsDebugger/YMCPhysicsDebugger/YMCSKNode+PhysicsDebug.m
+++ b/PhysicsDebugger/YMCPhysicsDebugger/YMCSKNode+PhysicsDebug.m
@@ -48,6 +48,11 @@ static NSString* debugLayerName = @"physicsDebugLayer";
         if(!node.physicsBody) {
             continue;
         }
+
+        //prevent exception if no nodes are found in array
+        if (![YMCPhysicsDebugProperties instance].nodesNBodies.count) {
+            continue;
+        }
         
         //clear all drawn physicDebugLayers of this node
         [[node childNodeWithName:debugLayerName] removeFromParent];


### PR DESCRIPTION
Minor change to prevent an exception being thrown if the nodesNBodies array has 0 objects.
